### PR TITLE
Implemented carbon intensity and generation mix endpoints

### DIFF
--- a/carbon_intensity/api/national.py
+++ b/carbon_intensity/api/national.py
@@ -1,14 +1,19 @@
 from typing import Optional, Any
 
-from pydantic import validate_arguments
+from pydantic import validate_arguments, PositiveInt
 from requests import Session
 
 from .base import BaseAPI
-from ..models.base import XMLResponse
+from ..custom_types import AnyDate, PeriodInteger, AnyDateTime
 from ..models.measurements import MeasurementResponse
 from ..models.factors import FactorResponse
-from ..models.mixes import GenerationMixResponse
-from ..custom_types import AnyDate, PeriodInteger, AnyDateTime
+from ..models.base import XMLResponse
+from ..models.mixes import (GenerationMixResponse,
+                            GenerationMixListResponse)
+from ..constraints import (check_interval,
+                           only_pendulum_kwargs,
+                           normalize_date,
+                           normalize_datetime)
 from ..constants import (
     CURRENT_INTENSITY_URL,
     INTENSITY_BY_DATE_URL,
@@ -24,6 +29,8 @@ class NationalJSONAPI(BaseAPI):
     def __init__(self, session: Session, **kwargs: Any):
         super().__init__(session=session, session_kwargs=kwargs)
 
+    # Carbon Intensity - National
+
     def get_current_intensity(self) -> MeasurementResponse:
         response = self._request_as_json(method="get", url=CURRENT_INTENSITY_URL)
         return MeasurementResponse(**response)
@@ -37,15 +44,10 @@ class NationalJSONAPI(BaseAPI):
         return FactorResponse(**response)
 
     @validate_arguments
-    def get_current_generation_mix(self) -> GenerationMixResponse:
-        response = self._request_as_json(method="get", url=GENERATION_MIX_URL)
-        return GenerationMixResponse(**response)
-
-    @validate_arguments
     def get_intensity_by_date(
         self, date: AnyDate, period: Optional[PeriodInteger] = None
     ) -> MeasurementResponse:
-        endpoint = f"{INTENSITY_BY_DATE_URL}/{date}"
+        endpoint = f"{INTENSITY_BY_DATE_URL}/{normalize_date(date)}"
         endpoint += f"/{period}" if period else str()
         response = self._request_as_json(method="get", url=endpoint)
         return MeasurementResponse(**response)
@@ -53,9 +55,70 @@ class NationalJSONAPI(BaseAPI):
     @validate_arguments
     def get_intensity_at(self, time: AnyDateTime) -> MeasurementResponse:
         response = self._request_as_json(
-            method="get", url=f"{CURRENT_INTENSITY_URL}/{time}"
+            method="get",
+            url=f"{CURRENT_INTENSITY_URL}/{normalize_datetime(time)}"
         )
         return MeasurementResponse(**response)
+
+    @validate_arguments
+    @only_pendulum_kwargs
+    def get_intensity_after(self, from_: AnyDateTime, **kwargs: PositiveInt) -> MeasurementResponse:
+        start = normalize_datetime(from_)
+        end = normalize_datetime(from_.add(**kwargs))
+        response = self._request_as_json(
+            method='get',
+            url=f'{CURRENT_INTENSITY_URL}/{start}/{end}'
+        )
+        return MeasurementResponse(**response)
+
+    @validate_arguments
+    @only_pendulum_kwargs
+    def get_intensity_before(self, from_: AnyDateTime, **kwargs: PositiveInt) -> MeasurementResponse:
+        start = normalize_datetime(from_.subtract(**kwargs))
+        end = normalize_datetime(from_)
+        response = self._request_as_json(
+            method='get',
+            url=f'{CURRENT_INTENSITY_URL}/{start}/{end}'
+        )
+        return MeasurementResponse(**response)
+
+    @validate_arguments
+    @check_interval
+    def get_intensity_between(self, from_: AnyDateTime, to: AnyDateTime) -> MeasurementResponse:
+        start = normalize_datetime(from_)
+        end = normalize_datetime(to)
+        response = self._request_as_json(
+            method='get',
+            url=f'{CURRENT_INTENSITY_URL}/{start}/{end}'
+        )
+        return MeasurementResponse(**response)
+
+    # Generation Mix - National (Beta)
+
+    @validate_arguments
+    def get_current_generation_mix(self) -> GenerationMixResponse:
+        response = self._request_as_json(method="get", url=GENERATION_MIX_URL)
+        return GenerationMixResponse(**response)
+
+    @validate_arguments
+    @only_pendulum_kwargs
+    def get_generation_mix_before(self, from_: AnyDateTime, **kwargs: PositiveInt) -> GenerationMixListResponse:
+        start = normalize_datetime(from_.subtract(**kwargs))
+        end = normalize_datetime(from_)
+        response = self._request_as_json(
+            method='get',
+            url=f'{GENERATION_MIX_URL}/{start}/{end}'
+        )
+        return GenerationMixListResponse(**response)
+
+    @validate_arguments
+    @check_interval
+    def get_generation_mix_between(self, from_: AnyDateTime, to: AnyDateTime) -> GenerationMixListResponse:
+        response = self._request_as_json(
+            method='get',
+            url=f'{GENERATION_MIX_URL}/{from_}/{to}'
+        )
+        return GenerationMixListResponse(**response)
 
 
 class NationalXMLAPI(BaseAPI):
@@ -78,7 +141,7 @@ class NationalXMLAPI(BaseAPI):
     def get_intensity_by_date(
         self, date: AnyDate, period: Optional[PeriodInteger] = None
     ) -> XMLResponse:
-        endpoint = f"{INTENSITY_BY_DATE_URL_XML}/{date}"
+        endpoint = f"{INTENSITY_BY_DATE_URL_XML}/{normalize_date(date)}"
         endpoint += f"/{period}" if period else str()
         response = self._request_as_xml(method="get", url=endpoint)
         return XMLResponse(response)
@@ -86,6 +149,40 @@ class NationalXMLAPI(BaseAPI):
     @validate_arguments
     def get_intensity_at(self, time: AnyDateTime) -> XMLResponse:
         response = self._request_as_xml(
-            method="get", url=f"{CURRENT_INTENSITY_URL_XML}/{time}"
+            method="get",
+            url=f"{CURRENT_INTENSITY_URL_XML}/{normalize_datetime(time)}"
+        )
+        return XMLResponse(response)
+
+    @validate_arguments
+    @only_pendulum_kwargs
+    def get_intensity_after(self, from_: AnyDateTime, **kwargs: PositiveInt) -> XMLResponse:
+        start = normalize_datetime(from_)
+        end = normalize_datetime(from_.add(**kwargs))
+        response = self._request_as_xml(
+            method='get',
+            url=f'{CURRENT_INTENSITY_URL_XML}/{start}/{end}'
+        )
+        return XMLResponse(response)
+
+    @validate_arguments
+    @only_pendulum_kwargs
+    def get_intensity_before(self, from_: AnyDateTime, **kwargs: PositiveInt) -> XMLResponse:
+        start = normalize_datetime(from_.subtract(**kwargs))
+        end = normalize_datetime(from_)
+        response = self._request_as_xml(
+            method='get',
+            url=f'{CURRENT_INTENSITY_URL_XML}/{start}/{end}'
+        )
+        return XMLResponse(response)
+
+    @validate_arguments
+    @check_interval
+    def get_intensity_between(self, from_: AnyDateTime, to: AnyDateTime) -> XMLResponse:
+        start = normalize_datetime(from_)
+        end = normalize_datetime(to)
+        response = self._request_as_xml(
+            method='get',
+            url=f'{CURRENT_INTENSITY_URL_XML}/{start}/{end}'
         )
         return XMLResponse(response)

--- a/carbon_intensity/constraints.py
+++ b/carbon_intensity/constraints.py
@@ -1,0 +1,44 @@
+from typing import Any, Callable
+
+from decorator import decorator
+
+from carbon_intensity.exceptions import APIConstraintException
+from carbon_intensity.constants import API_DATETIME_FORMAT, API_DATE_FORMAT
+from carbon_intensity.custom_types import AnyDate, AnyDateTime
+from carbon_intensity.constants import (
+    ALLOWED_PENDULUM_ARGS,
+    API_DATETIME_FORMAT,
+)
+
+
+@decorator
+def only_pendulum_kwargs(func: Callable, *args: Any, **kwargs: Any) -> None:
+    pendulum_args = set(kwargs.keys())
+
+    if not pendulum_args or not pendulum_args.issubset(ALLOWED_PENDULUM_ARGS):
+        raise APIConstraintException(
+            f"The allowed keywords for time interval are {ALLOWED_PENDULUM_ARGS}. "
+            f"Use only or at least one of them."
+        )
+
+    return func(*args, **kwargs)
+
+
+@decorator
+def check_interval(func: Callable, *args: Any, **kwargs: Any) -> None:
+    _, start_time, end_time = args
+
+    if start_time >= end_time:
+        raise APIConstraintException(
+            f"The start datetime should be less than the end datetime"
+        )
+
+    return func(*args, **kwargs)
+
+
+def normalize_datetime(datetime_obj: AnyDateTime) -> str:
+    return datetime_obj.strftime(API_DATETIME_FORMAT)
+
+
+def normalize_date(date_obj: AnyDate) -> str:
+    return date_obj.strftime(API_DATE_FORMAT)

--- a/carbon_intensity/exceptions.py
+++ b/carbon_intensity/exceptions.py
@@ -10,5 +10,5 @@ class XMLClientException(BaseAPIException):
     pass
 
 
-class ConstraintException(BaseAPIException):
+class APIConstraintException(BaseAPIException):
     pass

--- a/carbon_intensity/models/measurements.py
+++ b/carbon_intensity/models/measurements.py
@@ -20,8 +20,8 @@ class Intensity(IntensityForecast):
 
     def to_series(self) -> Series:
         record = super().to_series()
-        record.append(Series({"actual": self.actual}))
-        return record
+        actual_intensity = Series({"actual": self.actual})
+        return pd.concat([record, actual_intensity])
 
 
 class Measurement(BaseModel):

--- a/carbon_intensity/models/mixes.py
+++ b/carbon_intensity/models/mixes.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel, Field
 from pandas import DataFrame, Series
@@ -28,8 +28,15 @@ class GenerationMixDetails(BaseModel):
         return pd.Series(record)
 
 
+# Model for https://api.carbonintensity.org.uk/generation
 class GenerationMixResponse(BaseModel):
     data: GenerationMixDetails
 
     def to_dataframe(self) -> DataFrame:
         return pd.DataFrame([self.data.to_series()])
+
+
+# Model for https://api.carbonintensity.org.uk/generation/{from}/{to}
+class GenerationMixListResponse(BaseModel):
+    data: List[Optional[GenerationMixDetails]]
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,17 @@ import pathlib
 
 from lxml.etree import XMLSchema
 from lxml import etree
+import pendulum
 import pytest
 
 from carbon_intensity.api import JSONClient, XMLClient
 
 current_path = pathlib.Path(__file__).parent.absolute()
+
+# Dates for testing
+today = pendulum.now(tz='UTC')
+yesterday = today.subtract(days=1)
+tomorrow = today.add(days=1)
 
 
 @pytest.fixture(scope="class")

--- a/tests/national/test_client_exceptions.py
+++ b/tests/national/test_client_exceptions.py
@@ -1,5 +1,3 @@
-import pathlib
-
 import requests_mock
 import pytest
 

--- a/tests/national/test_generation_mix.py
+++ b/tests/national/test_generation_mix.py
@@ -1,0 +1,48 @@
+import pytest
+from pydantic import ValidationError
+
+from carbon_intensity.api import JSONClient
+from carbon_intensity.exceptions import APIConstraintException
+from ..conftest import yesterday, today
+from carbon_intensity.models.mixes import (GenerationMixResponse,
+                                           GenerationMixListResponse)
+
+
+@pytest.mark.usefixtures("json_api")
+class TestNationalGenerationMixAsJSON:
+    def test_current_generation_mix(self, json_api: JSONClient):
+        response = json_api.national.get_current_generation_mix()
+        assert isinstance(response, GenerationMixResponse)
+
+
+@pytest.mark.usefixtures("json_api")
+class TestNationalGenerationMixBeforeDateAsJSON:
+    def test_generation_mix_before(self, json_api: JSONClient):
+        response = json_api.national.get_generation_mix_before(from_=today, days=1)
+        assert isinstance(response, GenerationMixListResponse)
+
+    def test_generation_mix_with_invalid_kwargs(self, json_api: JSONClient):
+        with pytest.raises(APIConstraintException):
+            json_api.national.get_generation_mix_before(from_=today, lustrums=1)
+
+    def test_generation_mix_with_invalid_interval(self, json_api: JSONClient):
+        with pytest.raises(ValidationError):
+            json_api.national.get_generation_mix_before(from_=today, days=-1)
+
+
+@pytest.mark.usefixtures('json_api')
+class TestNationalGenerationMixBetweenDatesAsJSON:
+    def test_generation_mix_between(self, json_api: JSONClient) -> None:
+        response = json_api.national.get_generation_mix_between(
+            from_=yesterday,
+            to=today
+        )
+        assert isinstance(response, GenerationMixListResponse)
+
+    def test_exception_with_same_dates(self, json_api: JSONClient) -> None:
+        with pytest.raises(APIConstraintException):
+            json_api.national.get_generation_mix_between(from_=today, to=today)
+
+    def test_exception_with_invalid_interval(self, json_api: JSONClient) -> None:
+        with pytest.raises(APIConstraintException):
+            json_api.national.get_generation_mix_between(from_=today, to=yesterday)

--- a/tests/national/test_intensity_at_time.py
+++ b/tests/national/test_intensity_at_time.py
@@ -1,0 +1,22 @@
+from lxml.etree import XMLSchema
+import pytest
+
+from carbon_intensity.models.measurements import MeasurementResponse
+from carbon_intensity.api import JSONClient, XMLClient
+from ..conftest import today
+
+
+@pytest.mark.usefixtures("json_api")
+class TestNationalIntensityAtTimeAsJSON:
+    def test_intensity_at_time(self, json_api: JSONClient):
+        response = json_api.national.get_intensity_at(time=today)
+        assert isinstance(response, MeasurementResponse)
+
+
+@pytest.mark.usefixtures("xml_api", "measurement_schema")
+class TestNationalIntensityAtTimeAsXML:
+    def test_intensity_at_time(
+        self, xml_api: XMLClient, measurement_schema: XMLSchema
+    ) -> None:
+        response = xml_api.national.get_intensity_at(time=today)
+        measurement_schema.assertValid(response.document)

--- a/tests/national/test_intensity_by_date.py
+++ b/tests/national/test_intensity_by_date.py
@@ -2,38 +2,35 @@ import random
 
 from pydantic import ValidationError
 from lxml.etree import XMLSchema
-import pendulum
 import pytest
 
 from carbon_intensity.models.measurements import MeasurementResponse
 from carbon_intensity.constants import MIN_PERIOD, MAX_PERIOD
 from carbon_intensity.api import JSONClient, XMLClient
+from ..conftest import yesterday
 
 
 @pytest.mark.usefixtures("json_api")
 class TestNationalIntensityByDateAsJSON:
     def test_without_period(self, json_api: JSONClient) -> None:
-        yesterday = pendulum.now(tz="UTC").subtract(days=1)
         response = json_api.national.get_intensity_by_date(date=yesterday)
         assert isinstance(response, MeasurementResponse)
 
     def test_with_valid_period(self, json_api: JSONClient) -> None:
-        yesterday = pendulum.now(tz="UTC").subtract(days=1)
         period = random.randrange(MIN_PERIOD, MAX_PERIOD)
         response = json_api.national.get_intensity_by_date(
-            date=yesterday, period=period
+            date=yesterday,
+            period=period
         )
         assert isinstance(response, MeasurementResponse)
 
     def test_with_invalid_greater_period(self, json_api: JSONClient) -> None:
-        yesterday = pendulum.now(tz="UTC").subtract(days=1)
         period = MAX_PERIOD + 1
 
         with pytest.raises(ValidationError):
             json_api.national.get_intensity_by_date(date=yesterday, period=period)
 
     def test_with_invalid_lesser_period(self, json_api: JSONClient) -> None:
-        yesterday = pendulum.now(tz="UTC").subtract(days=1)
         period = MIN_PERIOD - 1
 
         with pytest.raises(ValidationError):
@@ -51,14 +48,12 @@ class TestNationalIntensityByDateAsXML:
     def test_without_period(
         self, xml_api: XMLClient, measurement_schema: XMLSchema
     ) -> None:
-        yesterday = pendulum.now(tz="UTC").subtract(days=1)
         response = xml_api.national.get_intensity_by_date(date=yesterday)
         measurement_schema.assertValid(response.document)
 
     def test_with_valid_period(
         self, xml_api: XMLClient, measurement_schema: XMLSchema
     ) -> None:
-        yesterday = pendulum.now(tz="UTC").subtract(days=1)
         period = random.randrange(MIN_PERIOD, MAX_PERIOD)
         response = xml_api.national.get_intensity_by_date(date=yesterday, period=period)
         measurement_schema.assertValid(response.document)
@@ -66,7 +61,6 @@ class TestNationalIntensityByDateAsXML:
     def test_with_invalid_greater_period(
         self, xml_api: XMLClient, measurement_schema: XMLSchema
     ) -> None:
-        yesterday = pendulum.now(tz="UTC").subtract(days=1)
         period = MAX_PERIOD + 1
 
         with pytest.raises(ValidationError):
@@ -75,7 +69,6 @@ class TestNationalIntensityByDateAsXML:
     def test_with_invalid_lesser_period(
         self, xml_api: XMLClient, measurement_schema: XMLSchema
     ) -> None:
-        yesterday = pendulum.now(tz="UTC").subtract(days=1)
         period = MIN_PERIOD - 1
 
         with pytest.raises(ValidationError):
@@ -88,21 +81,3 @@ class TestNationalIntensityByDateAsXML:
 
         with pytest.raises(ValidationError):
             xml_api.national.get_intensity_by_date(date=invalid_date)
-
-
-@pytest.mark.usefixtures("json_api")
-class TestNationalIntensityAtTimeAsJSON:
-    def test_intensity_at_time(self, json_api: JSONClient):
-        today = pendulum.today(tz="UTC")
-        response = json_api.national.get_intensity_at(time=today)
-        assert isinstance(response, MeasurementResponse)
-
-
-@pytest.mark.usefixtures("xml_api", "measurement_schema")
-class TestNationalIntensityAtTimeAsXML:
-    def test_intensity_at_time(
-        self, xml_api: XMLClient, measurement_schema: XMLSchema
-    ) -> None:
-        today = pendulum.today(tz="UTC")
-        response = xml_api.national.get_intensity_at(time=today)
-        measurement_schema.assertValid(response.document)

--- a/tests/national/test_intensity_by_interval.py
+++ b/tests/national/test_intensity_by_interval.py
@@ -1,0 +1,104 @@
+from pydantic import ValidationError
+from lxml.etree import XMLSchema
+import pytest
+
+from carbon_intensity.models.measurements import MeasurementResponse
+from carbon_intensity.exceptions import APIConstraintException
+from carbon_intensity.api import JSONClient, XMLClient
+from ..conftest import today, yesterday
+
+
+@pytest.mark.usefixtures("json_api")
+class TestNationalIntensityAfterDateAsJSON:
+    def test_intensity_after(self, json_api: JSONClient):
+        response = json_api.national.get_intensity_after(from_=today, days=1)
+        assert isinstance(response, MeasurementResponse)
+
+    def test_intensity_after_with_invalid_kwargs(self, json_api: JSONClient):
+        with pytest.raises(APIConstraintException):
+            json_api.national.get_intensity_after(from_=today, lustrums=1)
+
+    def test_intensity_after_with_invalid_interval(self, json_api: JSONClient):
+        with pytest.raises(ValidationError):
+            json_api.national.get_intensity_after(from_=today, days=-1)
+
+
+@pytest.mark.usefixtures("json_api")
+class TestNationalIntensityBeforeDateAsJSON:
+    def test_intensity_before(self, json_api: JSONClient):
+        response = json_api.national.get_intensity_before(from_=today, days=1)
+        assert isinstance(response, MeasurementResponse)
+
+    def test_intensity_before_with_invalid_kwargs(self, json_api: JSONClient):
+        with pytest.raises(APIConstraintException):
+            json_api.national.get_intensity_before(from_=today, lustrums=1)
+
+    def test_intensity_before_with_invalid_interval(self, json_api: JSONClient):
+        with pytest.raises(ValidationError):
+            json_api.national.get_intensity_before(from_=today, days=-1)
+
+
+@pytest.mark.usefixtures("json_api")
+class TestNationalIntensityBetweenDatesAsJSON:
+    def test_intensity_between(self, json_api: JSONClient) -> None:
+        response = json_api.national.get_intensity_between(
+            from_=yesterday,
+            to=today
+        )
+        assert isinstance(response, MeasurementResponse)
+
+    def test_exception_with_same_dates(self, json_api: JSONClient) -> None:
+        with pytest.raises(APIConstraintException):
+            json_api.national.get_intensity_between(from_=today, to=today)
+
+    def test_exception_with_invalid_interval(self, json_api: JSONClient) -> None:
+        with pytest.raises(APIConstraintException):
+            json_api.national.get_intensity_between(from_=today, to=yesterday)
+
+
+@pytest.mark.usefixtures("xml_api", "measurement_schema")
+class TestNationalIntensityAfterDateAsXML:
+    def test_intensity_after(self, xml_api: XMLClient, measurement_schema: XMLSchema) -> None:
+        response = xml_api.national.get_intensity_after(from_=today, days=1)
+        measurement_schema.assertValid(response.document)
+
+    def test_intensity_after_with_invalid_kwargs(self, xml_api: XMLClient) -> None:
+        with pytest.raises(APIConstraintException):
+            xml_api.national.get_intensity_after(from_=today, lustrums=1)
+
+    def test_intensity_after_with_invalid_interval(self, xml_api: XMLClient) -> None:
+        with pytest.raises(ValidationError):
+            xml_api.national.get_intensity_after(from_=today, days=-1)
+
+
+@pytest.mark.usefixtures("xml_api", "measurement_schema")
+class TestNationalIntensityBeforeDateAsXML:
+    def test_intensity_before(self, xml_api: XMLClient, measurement_schema: XMLSchema) -> None:
+        response = xml_api.national.get_intensity_before(from_=today, days=1)
+        measurement_schema.assertValid(response.document)
+
+    def test_intensity_before_with_invalid_kwargs(self, xml_api: XMLClient) -> None:
+        with pytest.raises(APIConstraintException):
+            xml_api.national.get_intensity_before(from_=today, lustrums=1)
+
+    def test_intensity_before_with_invalid_interval(self, xml_api: XMLClient) -> None:
+        with pytest.raises(ValidationError):
+            xml_api.national.get_intensity_before(from_=today, days=-1)
+
+
+@pytest.mark.usefixtures("xml_api", "measurement_schema")
+class TestNationalIntensityBetweenDatesAsXML:
+    def test_intensity_between(self, xml_api: XMLClient, measurement_schema: XMLSchema) -> None:
+        response = xml_api.national.get_intensity_between(
+            from_=yesterday,
+            to=today
+        )
+        measurement_schema.assertValid(response.document)
+
+    def test_exception_with_same_dates(self, xml_api: XMLClient) -> None:
+        with pytest.raises(APIConstraintException):
+            xml_api.national.get_intensity_between(from_=today, to=today)
+
+    def test_exception_with_invalid_interval(self, xml_api: XMLClient) -> None:
+        with pytest.raises(APIConstraintException):
+            xml_api.national.get_intensity_between(from_=today, to=yesterday)

--- a/tests/national/test_pandas_integration.py
+++ b/tests/national/test_pandas_integration.py
@@ -1,0 +1,39 @@
+import pytest
+
+from carbon_intensity.api import JSONClient
+
+
+@pytest.mark.usefixtures("json_api")
+class TestNationalPandasIntegration:
+    def test_intensity_response_to_dataframe(self, json_api: JSONClient):
+        response = json_api.national.get_current_intensity()
+        expected_columns = {
+            'from',
+            'to',
+            'actual',
+            'forecast',
+            'index'
+        }
+        dataframe = response.to_dataframe()
+        assert expected_columns.issubset(dataframe.columns)
+
+    def test_intensity_factor_response_to_dataframe(self, json_api: JSONClient):
+        response = json_api.national.get_intensity_factors()
+        expected_columns = {
+            'biomass',
+            'coal',
+            'dutch_imports',
+            'french_imports',
+            'gas_combined_cycle',
+            'gas_open_cycle',
+            'hydro',
+            'irish_imports',
+            'nuclear',
+            'oil',
+            'other',
+            'pumped_storage',
+            'solar',
+            'wind'
+        }
+        dataframe = response.to_dataframe()
+        assert expected_columns.issubset(dataframe.columns)


### PR DESCRIPTION
# JSON API

## Carbon Intensity - National

- [x] **GET /intensity/{from}/fw24h**
- Method **_get_intensity_after_** allows to specify other timedelta than 24 hours

- [x] **GET /intensity/{from}/fw48h**
- Method **_get_intensity_after_** allows to specify other timedelta than 48 hours

- [x] **GET /intensity/{from}/pt24h**
- Method **_get_intensity_before_** allows to specify other timedelta than 24 hours

- [x] **GET /intensity/{from}/{to}**
- Gets carbon intensity between specified datetimes

## Generation Mix - National (Beta)
- [x] **GET /generation**
- Gets current generation mix

- [x] **GET /generation/{from}/pt24h**
- Method **_get_generation_mix_before_** allows to specify other values than 24 hours

- [x] **GET /generation/{from}/{to}**
- Gets generation mix between specified datetimes

# XML API

## Carbon Intensity - National

- [x] **GET /intensity/{from}/fw24h**
- Method **_get_intensity_after_** allows to specify other timedelta than 24 hours

- [x] **GET /intensity/{from}/fw48h**
- Method **_get_intensity_after_** allows to specify other timedelta than 48 hours

- [x] **GET /intensity/{from}/pt24h**
- Method **_get_intensity_before_** allows to specify other timedelta than 24 hours

- [x] **GET /intensity/{from}/{to}**
- Gets carbon intensity between specified datetimes