### PR TITLE
Implemented intensity stats endpoints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ jobs:
     - name: "Python 3.9 on Xenial Linux"
       python: 3.9
 
-    - name: "Python Nightly on Xenial Linux"
-      python: nightly
-
     - name: "Python on macOS Catalina 10.15.7"
       os: osx
       osx_image: xcode12.2
@@ -63,18 +60,6 @@ jobs:
         - choco install python --version 3.9.2
         - python -m pip install --upgrade pip
       env: PATH=/c/Python39:/c/Python39/Scripts:$PATH
-
-    - name: "Python 3.10 prerelease version on Windows"
-      os: windows
-      language: shell
-      before_install:
-        - choco install python --pre
-        - python -m pip install --upgrade pip
-      env: PATH=/c/Python310:/c/Python310/Scripts:$PATH
-
-  allow_failures:
-    - name: "Python Nightly on Xenial Linux"
-    - name: "Python 3.10 prerelease version on Windows"
 
 install:
   - pip3 install -r ./requirements/development.txt

--- a/carbon_intensity/api/national.py
+++ b/carbon_intensity/api/national.py
@@ -4,16 +4,19 @@ from pydantic import validate_arguments, PositiveInt
 from requests import Session
 
 from .base import BaseAPI
-from ..custom_types import AnyDate, PeriodInteger, AnyDateTime
+from ..custom_types import AnyDate, PeriodInteger, AnyDateTime, BlockInteger
+from ..models.stats import StatsListResponse
 from ..models.measurements import MeasurementResponse
 from ..models.factors import FactorResponse
 from ..models.base import XMLResponse
-from ..models.mixes import (GenerationMixResponse,
-                            GenerationMixListResponse)
-from ..constraints import (check_interval,
-                           only_pendulum_kwargs,
-                           normalize_date,
-                           normalize_datetime)
+from ..models.mixes import GenerationMixResponse, GenerationMixListResponse
+from ..constraints import (
+    check_interval,
+    only_pendulum_kwargs,
+    normalize_date,
+    normalize_datetime,
+    max_interval,
+)
 from ..constants import (
     CURRENT_INTENSITY_URL,
     INTENSITY_BY_DATE_URL,
@@ -22,6 +25,8 @@ from ..constants import (
     CURRENT_INTENSITY_URL_XML,
     INTENSITY_BY_DATE_URL_XML,
     INTENSITY_FACTORS_URL_XML,
+    INTENSITY_STATS_URL,
+    INTENSITY_STATS_URL_XML,
 )
 
 
@@ -55,41 +60,43 @@ class NationalJSONAPI(BaseAPI):
     @validate_arguments
     def get_intensity_at(self, time: AnyDateTime) -> MeasurementResponse:
         response = self._request_as_json(
-            method="get",
-            url=f"{CURRENT_INTENSITY_URL}/{normalize_datetime(time)}"
+            method="get", url=f"{CURRENT_INTENSITY_URL}/{normalize_datetime(time)}"
         )
         return MeasurementResponse(**response)
 
     @validate_arguments
     @only_pendulum_kwargs
-    def get_intensity_after(self, from_: AnyDateTime, **kwargs: PositiveInt) -> MeasurementResponse:
+    def get_intensity_after(
+        self, from_: AnyDateTime, **kwargs: PositiveInt
+    ) -> MeasurementResponse:
         start = normalize_datetime(from_)
         end = normalize_datetime(from_.add(**kwargs))
         response = self._request_as_json(
-            method='get',
-            url=f'{CURRENT_INTENSITY_URL}/{start}/{end}'
+            method="get", url=f"{CURRENT_INTENSITY_URL}/{start}/{end}"
         )
         return MeasurementResponse(**response)
 
     @validate_arguments
     @only_pendulum_kwargs
-    def get_intensity_before(self, from_: AnyDateTime, **kwargs: PositiveInt) -> MeasurementResponse:
+    def get_intensity_before(
+        self, from_: AnyDateTime, **kwargs: PositiveInt
+    ) -> MeasurementResponse:
         start = normalize_datetime(from_.subtract(**kwargs))
         end = normalize_datetime(from_)
         response = self._request_as_json(
-            method='get',
-            url=f'{CURRENT_INTENSITY_URL}/{start}/{end}'
+            method="get", url=f"{CURRENT_INTENSITY_URL}/{start}/{end}"
         )
         return MeasurementResponse(**response)
 
     @validate_arguments
     @check_interval
-    def get_intensity_between(self, from_: AnyDateTime, to: AnyDateTime) -> MeasurementResponse:
+    def get_intensity_between(
+        self, from_: AnyDateTime, to: AnyDateTime
+    ) -> MeasurementResponse:
         start = normalize_datetime(from_)
         end = normalize_datetime(to)
         response = self._request_as_json(
-            method='get',
-            url=f'{CURRENT_INTENSITY_URL}/{start}/{end}'
+            method="get", url=f"{CURRENT_INTENSITY_URL}/{start}/{end}"
         )
         return MeasurementResponse(**response)
 
@@ -102,28 +109,45 @@ class NationalJSONAPI(BaseAPI):
 
     @validate_arguments
     @only_pendulum_kwargs
-    def get_generation_mix_before(self, from_: AnyDateTime, **kwargs: PositiveInt) -> GenerationMixListResponse:
+    def get_generation_mix_before(
+        self, from_: AnyDateTime, **kwargs: PositiveInt
+    ) -> GenerationMixListResponse:
         start = normalize_datetime(from_.subtract(**kwargs))
         end = normalize_datetime(from_)
         response = self._request_as_json(
-            method='get',
-            url=f'{GENERATION_MIX_URL}/{start}/{end}'
+            method="get", url=f"{GENERATION_MIX_URL}/{start}/{end}"
         )
         return GenerationMixListResponse(**response)
 
     @validate_arguments
     @check_interval
-    def get_generation_mix_between(self, from_: AnyDateTime, to: AnyDateTime) -> GenerationMixListResponse:
+    def get_generation_mix_between(
+        self, from_: AnyDateTime, to: AnyDateTime
+    ) -> GenerationMixListResponse:
         response = self._request_as_json(
-            method='get',
-            url=f'{GENERATION_MIX_URL}/{from_}/{to}'
+            method="get", url=f"{GENERATION_MIX_URL}/{from_}/{to}"
         )
         return GenerationMixListResponse(**response)
+
+    # Statistics - National
+
+    @validate_arguments
+    @max_interval(days=30)
+    def get_intensity_stats_between(
+        self, from_: AnyDateTime, to: AnyDateTime, block: Optional[BlockInteger] = None
+    ) -> StatsListResponse:
+
+        endpoint = f"{INTENSITY_STATS_URL}/{normalize_date(from_)}/{normalize_date(to)}"
+        endpoint += f"/{block}" if block else str()
+        response = self._request_as_json(method="get", url=endpoint)
+        return StatsListResponse(**response)
 
 
 class NationalXMLAPI(BaseAPI):
     def __init__(self, session: Session, **kwargs):
         super().__init__(session=session, session_kwargs=kwargs)
+
+    # Carbon Intensity - National
 
     def get_current_intensity(self) -> XMLResponse:
         response = self._request_as_xml(method="get", url=CURRENT_INTENSITY_URL_XML)
@@ -156,23 +180,25 @@ class NationalXMLAPI(BaseAPI):
 
     @validate_arguments
     @only_pendulum_kwargs
-    def get_intensity_after(self, from_: AnyDateTime, **kwargs: PositiveInt) -> XMLResponse:
+    def get_intensity_after(
+        self, from_: AnyDateTime, **kwargs: PositiveInt
+    ) -> XMLResponse:
         start = normalize_datetime(from_)
         end = normalize_datetime(from_.add(**kwargs))
         response = self._request_as_xml(
-            method='get',
-            url=f'{CURRENT_INTENSITY_URL_XML}/{start}/{end}'
+            method="get", url=f"{CURRENT_INTENSITY_URL_XML}/{start}/{end}"
         )
         return XMLResponse(response)
 
     @validate_arguments
     @only_pendulum_kwargs
-    def get_intensity_before(self, from_: AnyDateTime, **kwargs: PositiveInt) -> XMLResponse:
+    def get_intensity_before(
+        self, from_: AnyDateTime, **kwargs: PositiveInt
+    ) -> XMLResponse:
         start = normalize_datetime(from_.subtract(**kwargs))
         end = normalize_datetime(from_)
         response = self._request_as_xml(
-            method='get',
-            url=f'{CURRENT_INTENSITY_URL_XML}/{start}/{end}'
+            method="get", url=f"{CURRENT_INTENSITY_URL_XML}/{start}/{end}"
         )
         return XMLResponse(response)
 
@@ -182,7 +208,21 @@ class NationalXMLAPI(BaseAPI):
         start = normalize_datetime(from_)
         end = normalize_datetime(to)
         response = self._request_as_xml(
-            method='get',
-            url=f'{CURRENT_INTENSITY_URL_XML}/{start}/{end}'
+            method="get", url=f"{CURRENT_INTENSITY_URL_XML}/{start}/{end}"
         )
+        return XMLResponse(response)
+
+    # Statistics - National
+
+    @validate_arguments
+    @max_interval(days=30)
+    def get_intensity_stats_between(
+        self, from_: AnyDateTime, to: AnyDateTime, block: Optional[BlockInteger] = None
+    ) -> XMLResponse:
+
+        endpoint = (
+            f"{INTENSITY_STATS_URL_XML}/{normalize_date(from_)}/{normalize_date(to)}"
+        )
+        endpoint += f"/{block}" if block else str()
+        response = self._request_as_xml(method="get", url=endpoint)
         return XMLResponse(response)

--- a/carbon_intensity/constants.py
+++ b/carbon_intensity/constants.py
@@ -1,27 +1,37 @@
 BASE_URL = "https://api.carbonintensity.org.uk"
 
+# JSON API
 GENERATION_MIX_URL = f"{BASE_URL}/generation"
-
 CURRENT_INTENSITY_URL = f"{BASE_URL}/intensity"
 INTENSITY_BY_DATE_URL = f"{BASE_URL}/intensity/date"
 INTENSITY_FACTORS_URL = f"{BASE_URL}/intensity/factors"
 REGIONAL_INTENSITY_URL = f"{BASE_URL}/regional"
+INTENSITY_STATS_URL = f"{BASE_URL}/intensity/stats"
 
+# XML API
 CURRENT_INTENSITY_URL_XML = f"{BASE_URL}/xml/intensity"
 INTENSITY_BY_DATE_URL_XML = f"{BASE_URL}/xml/intensity/date"
 INTENSITY_FACTORS_URL_XML = f"{BASE_URL}/xml/intensity/factors"
 REGIONAL_INTENSITY_URL_XML = f"{BASE_URL}/xml/regional"
+INTENSITY_STATS_URL_XML = f"{BASE_URL}/xml/intensity/stats"
 
+# Normalized API Date/Datetime formats
 API_DATETIME_FORMAT = "%Y-%m-%dT%H:%MZ"
 API_DATE_FORMAT = "%Y-%m-%d"
 
+# Settlement period limits (Intensity by date)
 MIN_PERIOD = 1
 MAX_PERIOD = 48
 
-ALLOWED_COUNTRIES = ("england", "scotland", "wales")
+# Intensity stats block limits
+MIN_HOURS_BLOCK = 1
+MAX_HOURS_BLOCK = 24
 
-ALLOWED_COUNTRIES_REGEX = rf"^({'|'.join(ALLOWED_COUNTRIES)}$)"
+# Regional endpoints (Beta)
+ALLOWED_REGIONS = ("england", "scotland", "wales")
+ALLOWED_REGIONS_REGEX = rf"^({'|'.join(ALLOWED_REGIONS)}$)"
 
+# Allowed intervals to (before/after)-date-based endpoints.
 ALLOWED_PENDULUM_ARGS = {
     "years",
     "months",

--- a/carbon_intensity/constraints.py
+++ b/carbon_intensity/constraints.py
@@ -1,18 +1,19 @@
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 from decorator import decorator
+from pydantic import PositiveInt
 
 from carbon_intensity.exceptions import APIConstraintException
-from carbon_intensity.constants import API_DATETIME_FORMAT, API_DATE_FORMAT
 from carbon_intensity.custom_types import AnyDate, AnyDateTime
 from carbon_intensity.constants import (
     ALLOWED_PENDULUM_ARGS,
     API_DATETIME_FORMAT,
+    API_DATE_FORMAT
 )
 
 
 @decorator
-def only_pendulum_kwargs(func: Callable, *args: Any, **kwargs: Any) -> None:
+def only_pendulum_kwargs(func: Callable, *args: Any, **kwargs: Any) -> Callable:
     pendulum_args = set(kwargs.keys())
 
     if not pendulum_args or not pendulum_args.issubset(ALLOWED_PENDULUM_ARGS):
@@ -25,13 +26,26 @@ def only_pendulum_kwargs(func: Callable, *args: Any, **kwargs: Any) -> None:
 
 
 @decorator
-def check_interval(func: Callable, *args: Any, **kwargs: Any) -> None:
+def check_interval(func: Callable, *args: Any, **kwargs: Any) -> Callable:
     _, start_time, end_time = args
 
     if start_time >= end_time:
         raise APIConstraintException(
             f"The start datetime should be less than the end datetime"
         )
+
+    return func(*args, **kwargs)
+
+
+@decorator
+def max_interval(
+    func: Callable, days: Optional[PositiveInt] = None, *args: Any, **kwargs: Any
+) -> Callable:
+
+    _, start_time, end_time, block = args
+
+    if start_time >= end_time or (start_time - end_time).days > days:
+        raise APIConstraintException(f"Interval between dates must be max {days} days")
 
     return func(*args, **kwargs)
 

--- a/carbon_intensity/custom_types.py
+++ b/carbon_intensity/custom_types.py
@@ -4,10 +4,17 @@ from typing import Union
 from pydantic import conint, constr
 from pendulum import Date, DateTime
 
-from .constants import MIN_PERIOD, MAX_PERIOD, ALLOWED_COUNTRIES_REGEX
+from .constants import (
+    MIN_PERIOD,
+    MAX_PERIOD,
+    ALLOWED_REGIONS_REGEX,
+    MIN_HOURS_BLOCK,
+    MAX_HOURS_BLOCK,
+)
 
 
 AnyDateTime = Union[date, datetime, DateTime]
 AnyDate = Union[date, Date]
 PeriodInteger = conint(ge=MIN_PERIOD, le=MAX_PERIOD)
-RegionString = constr(to_lower=True, regex=ALLOWED_COUNTRIES_REGEX)
+BlockInteger = conint(ge=MIN_HOURS_BLOCK, le=MAX_HOURS_BLOCK)
+RegionString = constr(to_lower=True, regex=ALLOWED_REGIONS_REGEX)

--- a/carbon_intensity/models/stats.py
+++ b/carbon_intensity/models/stats.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+from pandas import DataFrame, Series
+import pandas as pd
+
+
+class IntensityStat(BaseModel):
+    max: int
+    average: int
+    min: int
+    index: str
+
+    def to_series(self) -> Series:
+        return pd.Series(self.dict())
+
+
+class StatsDetails(BaseModel):
+    from_: datetime = Field(..., alias="from")
+    to: datetime
+    intensity: IntensityStat = Field(..., alias="intensity")
+
+    def to_series(self) -> Series:
+        record = Series({"from": self.from_, "to": self.to})
+        return pd.concat([record, self.intensity.to_series()])
+
+
+# Model for https://api.carbonintensity.org.uk/intensity/stats/{from}/{to}
+class StatsListResponse(BaseModel):
+    data: List[Optional[StatsDetails]]
+
+    def to_dataframe(self) -> DataFrame:
+        return DataFrame([stats.to_series() for stats in self.data])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from carbon_intensity.api import JSONClient, XMLClient
 current_path = pathlib.Path(__file__).parent.absolute()
 
 # Dates for testing
-today = pendulum.now(tz='UTC')
+today = pendulum.now(tz="UTC")
 yesterday = today.subtract(days=1)
 tomorrow = today.add(days=1)
 
@@ -49,3 +49,12 @@ def factors_schema() -> XMLSchema:
     from the XML API
     """
     return XMLSchema(etree.parse(f"{current_path}/schemas/factors.xsd"))
+
+
+@pytest.fixture(scope="class")
+def stats_schema() -> XMLSchema:
+    """
+    Sets up the Stats XML schema to validate responses
+    from the XML API
+    """
+    return XMLSchema(etree.parse(f"{current_path}/schemas/stats.xml"))

--- a/tests/national/test_generation_mix.py
+++ b/tests/national/test_generation_mix.py
@@ -4,8 +4,10 @@ from pydantic import ValidationError
 from carbon_intensity.api import JSONClient
 from carbon_intensity.exceptions import APIConstraintException
 from ..conftest import yesterday, today
-from carbon_intensity.models.mixes import (GenerationMixResponse,
-                                           GenerationMixListResponse)
+from carbon_intensity.models.mixes import (
+    GenerationMixResponse,
+    GenerationMixListResponse,
+)
 
 
 @pytest.mark.usefixtures("json_api")
@@ -30,12 +32,11 @@ class TestNationalGenerationMixBeforeDateAsJSON:
             json_api.national.get_generation_mix_before(from_=today, days=-1)
 
 
-@pytest.mark.usefixtures('json_api')
+@pytest.mark.usefixtures("json_api")
 class TestNationalGenerationMixBetweenDatesAsJSON:
     def test_generation_mix_between(self, json_api: JSONClient) -> None:
         response = json_api.national.get_generation_mix_between(
-            from_=yesterday,
-            to=today
+            from_=yesterday, to=today
         )
         assert isinstance(response, GenerationMixListResponse)
 

--- a/tests/national/test_intensity_by_interval.py
+++ b/tests/national/test_intensity_by_interval.py
@@ -41,10 +41,7 @@ class TestNationalIntensityBeforeDateAsJSON:
 @pytest.mark.usefixtures("json_api")
 class TestNationalIntensityBetweenDatesAsJSON:
     def test_intensity_between(self, json_api: JSONClient) -> None:
-        response = json_api.national.get_intensity_between(
-            from_=yesterday,
-            to=today
-        )
+        response = json_api.national.get_intensity_between(from_=yesterday, to=today)
         assert isinstance(response, MeasurementResponse)
 
     def test_exception_with_same_dates(self, json_api: JSONClient) -> None:
@@ -58,7 +55,9 @@ class TestNationalIntensityBetweenDatesAsJSON:
 
 @pytest.mark.usefixtures("xml_api", "measurement_schema")
 class TestNationalIntensityAfterDateAsXML:
-    def test_intensity_after(self, xml_api: XMLClient, measurement_schema: XMLSchema) -> None:
+    def test_intensity_after(
+        self, xml_api: XMLClient, measurement_schema: XMLSchema
+    ) -> None:
         response = xml_api.national.get_intensity_after(from_=today, days=1)
         measurement_schema.assertValid(response.document)
 
@@ -73,7 +72,9 @@ class TestNationalIntensityAfterDateAsXML:
 
 @pytest.mark.usefixtures("xml_api", "measurement_schema")
 class TestNationalIntensityBeforeDateAsXML:
-    def test_intensity_before(self, xml_api: XMLClient, measurement_schema: XMLSchema) -> None:
+    def test_intensity_before(
+        self, xml_api: XMLClient, measurement_schema: XMLSchema
+    ) -> None:
         response = xml_api.national.get_intensity_before(from_=today, days=1)
         measurement_schema.assertValid(response.document)
 
@@ -88,11 +89,10 @@ class TestNationalIntensityBeforeDateAsXML:
 
 @pytest.mark.usefixtures("xml_api", "measurement_schema")
 class TestNationalIntensityBetweenDatesAsXML:
-    def test_intensity_between(self, xml_api: XMLClient, measurement_schema: XMLSchema) -> None:
-        response = xml_api.national.get_intensity_between(
-            from_=yesterday,
-            to=today
-        )
+    def test_intensity_between(
+        self, xml_api: XMLClient, measurement_schema: XMLSchema
+    ) -> None:
+        response = xml_api.national.get_intensity_between(from_=yesterday, to=today)
         measurement_schema.assertValid(response.document)
 
     def test_exception_with_same_dates(self, xml_api: XMLClient) -> None:

--- a/tests/national/test_intensity_stats.py
+++ b/tests/national/test_intensity_stats.py
@@ -1,0 +1,70 @@
+import pytest
+import random
+
+from lxml.etree import XMLSchema
+from pydantic import ValidationError
+
+from carbon_intensity.models.stats import StatsListResponse
+from carbon_intensity.api import JSONClient, XMLClient
+from carbon_intensity.constants import MIN_HOURS_BLOCK, MAX_HOURS_BLOCK
+from ..conftest import today, yesterday
+
+
+@pytest.mark.usefixtures("json_api")
+class TestNationalIntensityStatsAsJSON:
+    def test_intensity_stats_between(self, json_api: JSONClient) -> None:
+        response = json_api.national.get_intensity_stats_between(
+            from_=yesterday, to=today
+        )
+        assert isinstance(response, StatsListResponse)
+
+    def test_intensity_stats_between_with_block(self, json_api: JSONClient) -> None:
+        hours_block = random.randrange(MIN_HOURS_BLOCK, MAX_HOURS_BLOCK)
+        response = json_api.national.get_intensity_stats_between(
+            from_=yesterday, to=today, block=hours_block
+        )
+        assert isinstance(response, StatsListResponse)
+
+    def test_exception_with_invalid_lesser_block(self, json_api: JSONClient) -> None:
+        with pytest.raises(ValidationError):
+            json_api.national.get_intensity_stats_between(
+                from_=yesterday, to=today, block=MIN_HOURS_BLOCK - 1
+            )
+
+    def test_exception_with_invalid_greater_block(self, json_api: JSONClient) -> None:
+        with pytest.raises(ValidationError):
+            json_api.national.get_intensity_stats_between(
+                from_=yesterday, to=today, block=MAX_HOURS_BLOCK + 1
+            )
+
+
+@pytest.mark.usefixtures("xml_api", "stats_schema")
+class TestNationalIntensityStatsAsXML:
+    def test_intensity_stats_between(
+        self, xml_api: XMLClient, stats_schema: XMLSchema
+    ) -> None:
+        response = xml_api.national.get_intensity_stats_between(
+            from_=yesterday, to=today
+        )
+        stats_schema.assertValid(response.document)
+
+    def test_intensity_stats_between_with_block(
+        self, xml_api: XMLClient, stats_schema: XMLSchema
+    ) -> None:
+        hours_block = random.randrange(MIN_HOURS_BLOCK, MAX_HOURS_BLOCK)
+        response = xml_api.national.get_intensity_stats_between(
+            from_=yesterday, to=today, block=hours_block
+        )
+        stats_schema.assertValid(response.document)
+
+    def test_exception_with_invalid_lesser_block(self, xml_api: XMLClient) -> None:
+        with pytest.raises(ValidationError):
+            xml_api.national.get_intensity_stats_between(
+                from_=yesterday, to=today, block=MIN_HOURS_BLOCK - 1
+            )
+
+    def test_exception_with_invalid_greater_block(self, xml_api: XMLClient) -> None:
+        with pytest.raises(ValidationError):
+            xml_api.national.get_intensity_stats_between(
+                from_=yesterday, to=today, block=MAX_HOURS_BLOCK + 1
+            )

--- a/tests/national/test_pandas_integration.py
+++ b/tests/national/test_pandas_integration.py
@@ -7,33 +7,27 @@ from carbon_intensity.api import JSONClient
 class TestNationalPandasIntegration:
     def test_intensity_response_to_dataframe(self, json_api: JSONClient):
         response = json_api.national.get_current_intensity()
-        expected_columns = {
-            'from',
-            'to',
-            'actual',
-            'forecast',
-            'index'
-        }
+        expected_columns = {"from", "to", "actual", "forecast", "index"}
         dataframe = response.to_dataframe()
         assert expected_columns.issubset(dataframe.columns)
 
     def test_intensity_factor_response_to_dataframe(self, json_api: JSONClient):
         response = json_api.national.get_intensity_factors()
         expected_columns = {
-            'biomass',
-            'coal',
-            'dutch_imports',
-            'french_imports',
-            'gas_combined_cycle',
-            'gas_open_cycle',
-            'hydro',
-            'irish_imports',
-            'nuclear',
-            'oil',
-            'other',
-            'pumped_storage',
-            'solar',
-            'wind'
+            "biomass",
+            "coal",
+            "dutch_imports",
+            "french_imports",
+            "gas_combined_cycle",
+            "gas_open_cycle",
+            "hydro",
+            "irish_imports",
+            "nuclear",
+            "oil",
+            "other",
+            "pumped_storage",
+            "solar",
+            "wind",
         }
         dataframe = response.to_dataframe()
         assert expected_columns.issubset(dataframe.columns)

--- a/tests/regional/test_intensity.py
+++ b/tests/regional/test_intensity.py
@@ -2,7 +2,7 @@ from pydantic import ValidationError
 import pytest
 
 from carbon_intensity.models.regional import RegionListResponse, RegionResponse
-from carbon_intensity.constants import ALLOWED_COUNTRIES
+from carbon_intensity.constants import ALLOWED_REGIONS
 from carbon_intensity.api import JSONClient
 
 
@@ -12,7 +12,7 @@ class TestRegionalIntensityByDateAsJSON:
         response = json_api.regional.get_current_intensity()
         assert isinstance(response, RegionListResponse)
 
-    @pytest.mark.parametrize("region", ALLOWED_COUNTRIES)
+    @pytest.mark.parametrize("region", ALLOWED_REGIONS)
     def test_region_current_intensity(self, json_api: JSONClient, region: str) -> None:
         response = json_api.regional.get_region_current_intensity(region)
         assert isinstance(response, RegionResponse)

--- a/tests/schemas/stats.xml
+++ b/tests/schemas/stats.xml
@@ -1,0 +1,47 @@
+<xs:schema elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="response">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="responseMetadata">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element type="xs:short" name="httpCode"/>
+                            <xs:element type="xs:string" name="errorType"/>
+                            <xs:element type="xs:string" name="description"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="responseBody">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="responseList">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="item" maxOccurs="unbounded" minOccurs="0">
+                                            <xs:complexType>
+                                                <xs:sequence>
+                                                    <xs:element type="xs:string" name="timeFrom"/>
+                                                    <xs:element type="xs:string" name="timeTo"/>
+                                                    <xs:element name="intensity">
+                                                        <xs:complexType>
+                                                            <xs:sequence>
+                                                                <xs:element type="xs:short" name="max"/>
+                                                                <xs:element type="xs:short" name="average"/>
+                                                                <xs:element type="xs:short" name="min"/>
+                                                                <xs:element type="xs:string" name="index"/>
+                                                            </xs:sequence>
+                                                        </xs:complexType>
+                                                    </xs:element>
+                                                </xs:sequence>
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>


### PR DESCRIPTION
# JSON API

## Statistics - National

- [x] **GET /intensity/stats/{from}/{to}**
- Gets carbon intensity statistics between specified datetimes

- [x] **GET /intensity/stats/{from}/{to}/{block}**
- Gets carbon intensity statistics in blocks between specified datetimes

# XML API

## Statistics - National

- [x] **GET /intensity/stats/{from}/{to}**
- Gets carbon intensity statistics between specified datetimes

- [x] **GET /intensity/stats/{from}/{to}/{block}**
- Gets carbon intensity statistics in blocks between specified datetimes

# General
- Disabled Python Nightly versions on TravisCI